### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "src"

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ This version is little better in terms of giving different reply, as I have trai
 A Basic Chat looks like:
 
 ![discord](https://user-images.githubusercontent.com/7776994/57831059-b2043080-77d1-11e9-8596-a149cab80cad.PNG)
-
+[![Run on Repl.it](https://repl.it/badge/github/gopesh-sharma/LetsChat)](https://repl.it/github/gopesh-sharma/LetsChat)
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@HunterKiTe/LetsChat).